### PR TITLE
[url_image_preview] Move download folder

### DIFF
--- a/url_image_preview/url_image_preview.py
+++ b/url_image_preview/url_image_preview.py
@@ -133,7 +133,7 @@ class Base(object):
         self.textview = self.chat_control.conv_textview
         self.handlers = {}
 
-        self.directory = os.path.join(configpaths.gajimpaths['MY_DATA'],
+        self.directory = os.path.join(configpaths.gajimpaths['MY_CACHE'],
                                       'downloads')
         self.thumbpath = os.path.join(configpaths.gajimpaths['MY_CACHE'],
                                       'downloads.thumb')

--- a/url_image_preview/url_image_preview.py
+++ b/url_image_preview/url_image_preview.py
@@ -134,9 +134,9 @@ class Base(object):
         self.handlers = {}
 
         self.directory = os.path.join(configpaths.gajimpaths['MY_CACHE'],
-                                      'downloads')
+                                      'url_image_preview')
         self.thumbpath = os.path.join(configpaths.gajimpaths['MY_CACHE'],
-                                      'downloads.thumb')
+                                      'url_image_preview.thumb')
 
         try:
             self._create_path(self.directory)


### PR DESCRIPTION
Currently `url_image_preview` downloads all received images and stores them on disk _indefinitely_. I think the desired behavior would be more similar to what web browsers do with images. By that I mean that the images can be _temporarily_ cached on RAM or disk, but they are not stored. There was discussion about this on https://dev.gajim.org/gajim/gajim-plugins/issues/139.

In this pull request I have two commits and would like to hear comments on both. The first one moves the download directory from `~/.local/share/gajim/downloads` to `~/.cache/gajim/downloads` (actually `$XDG_CACHE_HOME`, `configpaths.gajimpaths['MY_CACHE']`). This is more suitable location for temporary cache files. Users may have this location on a ramdisk and they may have it excluded from automatic backup systems etc. The cache folder can be safely cleaned since it should only contain temporary files.

The other commit renames the folder to `url_image_preview`. The previous name, `downloads`, would imply that the files are explicitly downloaded by the user. I'm not sure what would be the ideal directory name, but I think it is safe to use the plugin name.

PS. I tried to create this pull request on dev.gajim.org, but it seems I don't have enough permissions for that.